### PR TITLE
chore: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "chalk": "5.4.1",
+        "chalk": "5.5.0",
         "each-async": "^2.0.0",
         "indent-string": "^5.0.0",
-        "npm-check-updates": "^18.0.1",
-        "playwright-qase-reporter": "2.1.3"
+        "npm-check-updates": "^18.0.2",
+        "playwright-qase-reporter": "2.1.4"
       },
       "devDependencies": {
-        "@playwright/test": "^1.53.1",
-        "@types/node": "^24.0.4",
-        "playwright": "^1.53.1"
+        "@playwright/test": "^1.54.2",
+        "@types/node": "^24.2.0",
+        "playwright": "^1.54.2"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.53.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
-      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.53.1"
+        "playwright": "1.54.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -37,13 +37,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
-      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
+      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/ajv": {
@@ -137,9 +137,10 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
+      "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -544,9 +545,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.0.1.tgz",
-      "integrity": "sha512-MO7mLp/8nm6kZNLLyPgz4gHmr9tLoU+pWPLdXuGAx+oZydBHkHWN0ibTonsrfwC2WEQNIQxuZagYwB67JQpAuw==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.0.2.tgz",
+      "integrity": "sha512-9uVFZUCg5oDOcbzdsrJ4BEvq2gikd23tXuF5mqpl4mxVl051lzB00Xmd7ZVjVWY3XNUF3BQKWlN/qmyD8/bwrA==",
       "license": "Apache-2.0",
       "bin": {
         "ncu": "build/cli.js",
@@ -566,12 +567,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.53.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
-      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.53.1"
+        "playwright-core": "1.54.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -584,9 +585,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.53.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
-      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -596,9 +597,9 @@
       }
     },
     "node_modules/playwright-qase-reporter": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.1.3.tgz",
-      "integrity": "sha512-YQExGwjXiHNFdee/JKfM78Ic/jZlabZI9CMFdiGlrDieFf/JAtGmfIDqA+5UmRtrohdkMkhvqEvZTla6DaWdWg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.1.4.tgz",
+      "integrity": "sha512-ou20ehaXLjL0c6kE0ywwX8PZSs/XLE3pMfkhvXc7owXAVEmvf3hNRbPzBK37Ayaesi/P175IL9GYH+vOLMTrcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -746,9 +747,9 @@
       "license": "0BSD"
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
   },
   "homepage": "https://github.com/estefafdez/playwright-template#readme",
   "devDependencies": {
-    "@playwright/test": "^1.53.1",
-    "@types/node": "^24.0.4",
-    "playwright": "^1.53.1"
+    "@playwright/test": "^1.54.2",
+    "@types/node": "^24.2.0",
+    "playwright": "^1.54.2"
   },
 "dependencies": {
-"chalk": "5.4.1",
+"chalk": "5.5.0",
     "each-async": "^2.0.0",
     "indent-string": "^5.0.0",
-    "npm-check-updates": "^18.0.1",
-    "playwright-qase-reporter": "2.1.3"
+    "npm-check-updates": "^18.0.2",
+    "playwright-qase-reporter": "2.1.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,19 @@
 # yarn lockfile v1
 
 
-"@playwright/test@^1.53.1", "@playwright/test@>=1.16.3":
-  version "1.53.1"
-  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz"
-  integrity sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==
+"@playwright/test@^1.54.2", "@playwright/test@>=1.16.3":
+  version "1.54.2"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz"
+  integrity sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==
   dependencies:
-    playwright "1.53.1"
+    playwright "1.54.2"
 
-"@types/node@^24.0.4":
-  version "24.0.4"
-  resolved "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz"
-  integrity sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==
+"@types/node@^24.2.0":
+  version "24.2.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz"
+  integrity sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==
   dependencies:
-    undici-types "~7.8.0"
+    undici-types "~7.10.0"
 
 ajv@^8.0.0, ajv@^8.12.0:
   version "8.17.1"
@@ -82,10 +82,10 @@ chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@5.4.1:
-  version "5.4.1"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz"
-  integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
+chalk@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz"
+  integrity sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -305,36 +305,36 @@ mime-types@^2.1.12, mime-types@^2.1.33:
   dependencies:
     mime-db "1.52.0"
 
-npm-check-updates@^18.0.1:
-  version "18.0.1"
-  resolved "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.0.1.tgz"
-  integrity sha512-MO7mLp/8nm6kZNLLyPgz4gHmr9tLoU+pWPLdXuGAx+oZydBHkHWN0ibTonsrfwC2WEQNIQxuZagYwB67JQpAuw==
+npm-check-updates@^18.0.2:
+  version "18.0.2"
+  resolved "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.0.2.tgz"
+  integrity sha512-9uVFZUCg5oDOcbzdsrJ4BEvq2gikd23tXuF5mqpl4mxVl051lzB00Xmd7ZVjVWY3XNUF3BQKWlN/qmyD8/bwrA==
 
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
   integrity sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==
 
-playwright-core@1.53.1:
-  version "1.53.1"
-  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz"
-  integrity sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==
+playwright-core@1.54.2:
+  version "1.54.2"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz"
+  integrity sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==
 
-playwright-qase-reporter@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.1.3.tgz"
-  integrity sha512-YQExGwjXiHNFdee/JKfM78Ic/jZlabZI9CMFdiGlrDieFf/JAtGmfIDqA+5UmRtrohdkMkhvqEvZTla6DaWdWg==
+playwright-qase-reporter@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.1.4.tgz"
+  integrity sha512-ou20ehaXLjL0c6kE0ywwX8PZSs/XLE3pMfkhvXc7owXAVEmvf3hNRbPzBK37Ayaesi/P175IL9GYH+vOLMTrcA==
   dependencies:
     chalk "^4.1.2"
     qase-javascript-commons "~2.3.3"
     uuid "^9.0.0"
 
-playwright@^1.53.1, playwright@1.53.1:
-  version "1.53.1"
-  resolved "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz"
-  integrity sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==
+playwright@^1.54.2, playwright@1.54.2:
+  version "1.54.2"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz"
+  integrity sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==
   dependencies:
-    playwright-core "1.53.1"
+    playwright-core "1.54.2"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -407,10 +407,10 @@ tslib@^2.4.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
-undici-types@~7.8.0:
-  version "7.8.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz"
-  integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
+undici-types@~7.10.0:
+  version "7.10.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz"
+  integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
 
 uuid@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
This pull request updates several dependencies in the `package.json` file to their latest versions. These updates ensure the project uses the most recent features and security patches.

Dependency updates:

* Upgraded `@playwright/test` and `playwright` from version `1.53.1` to `1.54.2` to ensure compatibility with the latest Playwright features and bug fixes.
* Updated `@types/node` from `24.0.4` to `24.2.0` for improved type definitions.
* Bumped `chalk` from `5.4.1` to `5.5.0` for the latest enhancements.
* Updated `npm-check-updates` from `18.0.1` to `18.0.2` and `playwright-qase-reporter` from `2.1.3` to `2.1.4` for minor improvements and fixes.