### PR TITLE
ci(playwright): add testdino reporter to workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,7 +43,7 @@ jobs:
           comment_title: "Playwright Test Results"
       - name: Testdino Reporter
         run:
-          npx --yes tdpw playwright-report/ --token="${TESTDINO_API}" --upload-html
+          npx --yes tdpw playwright-report/ --token="${TDPW_API_KEY}" --upload-html
         env:
           TDPW_API_KEY: ${{ secrets.TESTDINO_API }}    
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,6 +41,11 @@ jobs:
           files: playwright-report/xray-report.xml
           check_name: "Playwright Test Results"
           comment_title: "Playwright Test Results"
+      - name: Testdino Reporter
+        run:
+          npx --yes tdpw playwright-report/ --token="${TESTDINO_API}" --upload-html
+        env:
+          TDPW_API_KEY: ${{ secrets.TESTDINO_API }}    
 
       - name: Notify Slack
         uses: ravsamhq/notify-slack-action@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "chalk": "5.5.0",
+        "chalk": "5.6.0",
         "each-async": "^2.0.0",
         "indent-string": "^5.0.0",
         "npm-check-updates": "^18.0.2",
-        "playwright-qase-reporter": "2.1.4"
+        "playwright-qase-reporter": "2.1.5"
       },
       "devDependencies": {
-        "@playwright/test": "^1.54.2",
-        "@types/node": "^24.2.0",
-        "playwright": "^1.54.2"
+        "@playwright/test": "^1.55.0",
+        "@types/node": "^24.3.0",
+        "playwright": "^1.55.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
-      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.54.2"
+        "playwright": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
-      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -101,13 +101,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
-      "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
+      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -312,9 +312,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -567,12 +567,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.54.2"
+        "playwright-core": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -597,13 +597,13 @@
       }
     },
     "node_modules/playwright-qase-reporter": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.1.4.tgz",
-      "integrity": "sha512-ou20ehaXLjL0c6kE0ywwX8PZSs/XLE3pMfkhvXc7owXAVEmvf3hNRbPzBK37Ayaesi/P175IL9GYH+vOLMTrcA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.1.5.tgz",
+      "integrity": "sha512-5WsZ+Lca03hxVY8xIIVyFd8w0z+nMTrnBp9po+3v2UAbf5d9wGQPqbELPtV3/1DfxlTiOzWy5Q4VWgJ0X/vouA==",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
-        "qase-javascript-commons": "~2.3.3",
+        "qase-javascript-commons": "~2.4.1",
         "uuid": "^9.0.0"
       },
       "engines": {
@@ -635,9 +635,9 @@
       "license": "MIT"
     },
     "node_modules/qase-api-client": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.0.2.tgz",
-      "integrity": "sha512-3+HapZS4yYB/kmKcEF3JtPT3hx8RkYADoZSLH6lSoaZJdCz+NHcPBZGYvfojhdMngoXZlQs3xydszx6KsJGAPg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.0.5.tgz",
+      "integrity": "sha512-Y/xsiQBofnRdAzDqWFFl305igFiqLYcJN5Tkn7J86i5wja28ifHvJsvg8yr0kU9CV5/h1hArpu5m29sRnziuHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",
@@ -661,16 +661,16 @@
       }
     },
     "node_modules/qase-javascript-commons": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.3.5.tgz",
-      "integrity": "sha512-eVJLSYZF8D1xqQZ9iX7WQltGKvSZ/CW1wH6YNM/ANtSVYnCuJuGoFFPtJrLjJmmvNCl15DgG18Fv2044b8g5kw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.4.1.tgz",
+      "integrity": "sha512-B/aYqeyGLH6OGe/93pXpDlALm/W6+5NSv//wsDk3MOlKm1JzaXZ2ADyvtVRvGfiTav2tv6jPS8tTXu7LOk/dXA==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
         "async-mutex": "~0.5.0",
         "chalk": "^4.1.2",
         "env-schema": "^5.2.0",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
   },
   "homepage": "https://github.com/estefafdez/playwright-template#readme",
   "devDependencies": {
-    "@playwright/test": "^1.54.2",
-    "@types/node": "^24.2.0",
-    "playwright": "^1.54.2"
+    "@playwright/test": "^1.55.0",
+    "@types/node": "^24.3.0",
+    "playwright": "^1.55.0"
   },
 "dependencies": {
-"chalk": "5.5.0",
+"chalk": "5.6.0",
     "each-async": "^2.0.0",
     "indent-string": "^5.0.0",
     "npm-check-updates": "^18.0.2",
-    "playwright-qase-reporter": "2.1.4"
+    "playwright-qase-reporter": "2.1.5"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,6 +51,7 @@ const config: PlaywrightTestConfig = {
     ["html", { open: "on-failure" }],
     ["junit", xrayOptions],
     ["list", { printSteps: true }],
+    ["json", { outputFile: "playwright-report/results.json" }],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@playwright/test@^1.54.2", "@playwright/test@>=1.16.3":
-  version "1.54.2"
-  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz"
-  integrity sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==
+"@playwright/test@^1.55.0", "@playwright/test@>=1.16.3":
+  version "1.55.0"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz"
+  integrity sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==
   dependencies:
-    playwright "1.54.2"
+    playwright "1.55.0"
 
-"@types/node@^24.2.0":
-  version "24.2.0"
-  resolved "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz"
-  integrity sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==
+"@types/node@^24.3.0":
+  version "24.3.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz"
+  integrity sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==
   dependencies:
     undici-types "~7.10.0"
 
@@ -58,12 +58,12 @@ axios-retry@^4.5.0:
     is-retry-allowed "^2.2.0"
 
 axios@^1.8.2, "axios@0.x || 1.x":
-  version "1.10.0"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz"
-  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
+  version "1.11.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz"
+  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
   dependencies:
     follow-redirects "^1.15.6"
-    form-data "^4.0.0"
+    form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
@@ -82,10 +82,10 @@ chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz"
-  integrity sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==
+chalk@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz"
+  integrity sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -117,9 +117,9 @@ dotenv-expand@^10.0.0:
   integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
 
 dotenv@^16.0.0:
-  version "16.5.0"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz"
-  integrity sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==
+  version "16.6.1"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
 
 dunder-proto@^1.0.1:
   version "1.0.1"
@@ -185,14 +185,14 @@ fast-uri@^3.0.1:
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
 follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+  version "1.15.11"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
-form-data@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz"
-  integrity sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -315,26 +315,26 @@ onetime@^1.0.0:
   resolved "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
   integrity sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==
 
-playwright-core@1.54.2:
-  version "1.54.2"
-  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz"
-  integrity sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==
+playwright-core@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz"
+  integrity sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==
 
-playwright-qase-reporter@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.1.4.tgz"
-  integrity sha512-ou20ehaXLjL0c6kE0ywwX8PZSs/XLE3pMfkhvXc7owXAVEmvf3hNRbPzBK37Ayaesi/P175IL9GYH+vOLMTrcA==
+playwright-qase-reporter@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.1.5.tgz"
+  integrity sha512-5WsZ+Lca03hxVY8xIIVyFd8w0z+nMTrnBp9po+3v2UAbf5d9wGQPqbELPtV3/1DfxlTiOzWy5Q4VWgJ0X/vouA==
   dependencies:
     chalk "^4.1.2"
-    qase-javascript-commons "~2.3.3"
+    qase-javascript-commons "~2.4.1"
     uuid "^9.0.0"
 
-playwright@^1.54.2, playwright@1.54.2:
-  version "1.54.2"
-  resolved "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz"
-  integrity sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==
+playwright@^1.55.0, playwright@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz"
+  integrity sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==
   dependencies:
-    playwright-core "1.54.2"
+    playwright-core "1.55.0"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -344,9 +344,9 @@ proxy-from-env@^1.1.0:
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 qase-api-client@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.0.2.tgz"
-  integrity sha512-3+HapZS4yYB/kmKcEF3JtPT3hx8RkYADoZSLH6lSoaZJdCz+NHcPBZGYvfojhdMngoXZlQs3xydszx6KsJGAPg==
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.0.5.tgz"
+  integrity sha512-Y/xsiQBofnRdAzDqWFFl305igFiqLYcJN5Tkn7J86i5wja28ifHvJsvg8yr0kU9CV5/h1hArpu5m29sRnziuHw==
   dependencies:
     axios "^1.8.2"
     axios-retry "^4.5.0"
@@ -359,16 +359,16 @@ qase-api-v2-client@~1.0.1:
     axios "^1.8.2"
     axios-retry "^4.5.0"
 
-qase-javascript-commons@~2.3.3:
-  version "2.3.5"
-  resolved "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.3.5.tgz"
-  integrity sha512-eVJLSYZF8D1xqQZ9iX7WQltGKvSZ/CW1wH6YNM/ANtSVYnCuJuGoFFPtJrLjJmmvNCl15DgG18Fv2044b8g5kw==
+qase-javascript-commons@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.4.1.tgz"
+  integrity sha512-B/aYqeyGLH6OGe/93pXpDlALm/W6+5NSv//wsDk3MOlKm1JzaXZ2ADyvtVRvGfiTav2tv6jPS8tTXu7LOk/dXA==
   dependencies:
     ajv "^8.12.0"
     async-mutex "~0.5.0"
     chalk "^4.1.2"
     env-schema "^5.2.0"
-    form-data "^4.0.0"
+    form-data "^4.0.4"
     lodash.get "^4.4.2"
     lodash.merge "^4.6.2"
     lodash.mergewith "^4.6.2"


### PR DESCRIPTION
This pull request introduces a new step to the Playwright GitHub Actions workflow to integrate with an external test reporting tool. The main change is the addition of the Testdino Reporter step, which uploads Playwright test reports to Testdino using a secure API key.

### Workflow integration

* Added a new job step named "Testdino Reporter" to `.github/workflows/playwright.yml` that runs `npx --yes tdpw playwright-report/ --token="${TESTDINO_API}" --upload-html` and sets the `TDPW_API_KEY` environment variable from GitHub secrets.