### PR TITLE
Integrate playwright-opentelemetry for test tracing

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -59,6 +59,14 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-opentelemetry-zips
+          path: test-results/**/*-pw-otel.zip
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -59,11 +59,15 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
+      - name: Archive OpenTelemetry traces
+        if: always()
+        run: find test-results -name '*-pw-otel.zip' -print0 2>/dev/null | tar -czf playwright-opentelemetry-zips.tar.gz --null -T - || true
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-opentelemetry-zips
-          path: test-results/**/*-pw-otel.zip
+          path: playwright-opentelemetry-zips.tar.gz
           if-no-files-found: warn
           retention-days: 30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@playwright/test": "^1.61.1",
         "@types/node": "^26.1.1",
         "dotenv": "^17.4.2",
-        "playwright": "^1.61.1"
+        "playwright": "^1.61.1",
+        "playwright-opentelemetry": "^0.12.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -99,6 +100,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.34",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.34.tgz",
+      "integrity": "sha512-+6a3lyqq69rpseLbvDPiVIWsZ/HdTGAAD6afFtug6ECPDGttb2dHnPC6cJgdPofYkzL9OvXizegq+DQVfL2rnA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -931,6 +944,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright-opentelemetry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/playwright-opentelemetry/-/playwright-opentelemetry-0.12.1.tgz",
+      "integrity": "sha512-EmNoFAEByheO/CYgCUO7glmUtZZqIBn5hbXuMNQfcWCeC5LeaFMxg2KzWTsiWSqE/Nbg9Trz2LPIWbOfhyRA1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@zip.js/zip.js": "^2.8.26"
+      },
+      "peerDependencies": {
+        "@playwright/test": "*"
       }
     },
     "node_modules/playwright-qase-reporter": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "playwright-template",
   "version": "1.0.0",
+  "type": "module",
   "description": "Example of a project with Playwright, Typescript and some integrations.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@playwright/test": "^1.61.1",
     "@types/node": "^26.1.1",
     "dotenv": "^17.4.2",
-    "playwright": "^1.61.1"
+    "playwright": "^1.61.1",
+    "playwright-opentelemetry": "^0.12.1"
   },
   "dependencies": {
     "@testdino/playwright": "^2.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,25 @@
-import type { PlaywrightTestConfig } from "@playwright/test";
-import { devices } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
+import type {
+  PlaywrightOpentelemetryConfig,
+  PlaywrightOpentelemetryUseOptions,
+} from "playwright-opentelemetry/fixture" with { "resolution-mode": "import" };
+import "dotenv/config";
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-require('dotenv').config();
+const honeycombApiKey = process.env.HONEYCOMB_API_KEY;
+
+const playwrightOpentelemetry: PlaywrightOpentelemetryConfig = {
+  otlpEndpoint: {
+    url: "https://api.eu1.honeycomb.io/v1/traces",
+    ...(honeycombApiKey
+      ? {
+          headers: {
+            "x-honeycomb-team": honeycombApiKey,
+          },
+        }
+      : {}),
+  },
+  storeTraceZip: true,
+};
 
 // JUnit reporter config for Xray
 const xrayOptions = {
@@ -27,7 +41,7 @@ const xrayOptions = {
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-const config: PlaywrightTestConfig = {
+export default defineConfig<PlaywrightOpentelemetryUseOptions>({
   testDir: "./tests",
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
@@ -48,6 +62,7 @@ const config: PlaywrightTestConfig = {
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
+    ["playwright-opentelemetry/reporter"],
     ["html", { open: "on-failure" }],
     ["junit", xrayOptions],
     ["list", { printSteps: true }],
@@ -58,7 +73,8 @@ const config: PlaywrightTestConfig = {
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     actionTimeout: 10000,
-    trace: "on-first-retry",
+    playwrightOpentelemetry,
+    trace: "retain-on-failure",
     screenshot: "only-on-failure",
     headless: true, // Set to false if you want to see the browser during tests
   },
@@ -86,6 +102,4 @@ const config: PlaywrightTestConfig = {
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: "test-results/",
-};
-
-export default config;
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,9 +27,9 @@ const xrayOptions = {
   outputFile: "playwright-report/xray-report.xml",
 };
 
-const testDinoToken = process.env.TESTDINO_TOKEN?.trim();
+const testDinoToken = process.env.TESTDINO_TOKEN?.trim() || undefined;
 
-const createReporter = (): NonNullable<PlaywrightTestConfig["reporter"]> => {
+const getReporterConfig = (): NonNullable<PlaywrightTestConfig["reporter"]> => {
   const baseReporter: NonNullable<PlaywrightTestConfig["reporter"]> = [
     ["playwright-opentelemetry/reporter"],
     ["html", { open: "on-failure" }],
@@ -66,7 +66,7 @@ export default defineConfig<PlaywrightOpentelemetryUseOptions>({
   /* Opt out of parallel tests on CI. Undefined means that pw will take care of it */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: createReporter(),
+  reporter: getReporterConfig(),
   /* Shared timeout for all tests. This is useful for long-running tests. */
   globalTimeout: 15 * 60 * 1000, // 15 minutes
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,19 +5,7 @@ import type {
 } from "playwright-opentelemetry/fixture" with { "resolution-mode": "import" };
 import "dotenv/config";
 
-const honeycombApiKey = process.env.HONEYCOMB_API_KEY;
-
 const playwrightOpentelemetry: PlaywrightOpentelemetryConfig = {
-  otlpEndpoint: {
-    url: "https://api.eu1.honeycomb.io/v1/traces",
-    ...(honeycombApiKey
-      ? {
-          headers: {
-            "x-honeycomb-team": honeycombApiKey,
-          },
-        }
-      : {}),
-  },
   storeTraceZip: true,
 };
 
@@ -74,7 +62,7 @@ export default defineConfig<PlaywrightOpentelemetryUseOptions>({
   use: {
     actionTimeout: 10000,
     playwrightOpentelemetry,
-    trace: "retain-on-failure",
+    trace: "on",
     screenshot: "only-on-failure",
     headless: true, // Set to false if you want to see the browser during tests
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import type { PlaywrightTestConfig } from "@playwright/test";
 import type {
   PlaywrightOpentelemetryConfig,
   PlaywrightOpentelemetryUseOptions,
@@ -28,17 +29,19 @@ const xrayOptions = {
 
 const testDinoToken = process.env.TESTDINO_TOKEN?.trim();
 
-const reporter = [
-  ["playwright-opentelemetry/reporter"],
-  ["html", { open: "on-failure" }],
-  ["junit", xrayOptions],
-  ["list", { printSteps: true }],
-  ["json", { outputFile: "playwright-report/results.json" }],
-];
+const createReporter = (): NonNullable<PlaywrightTestConfig["reporter"]> => {
+  const baseReporter: NonNullable<PlaywrightTestConfig["reporter"]> = [
+    ["playwright-opentelemetry/reporter"],
+    ["html", { open: "on-failure" }],
+    ["junit", xrayOptions],
+    ["list", { printSteps: true }],
+    ["json", { outputFile: "playwright-report/results.json" }],
+  ];
 
-if (testDinoToken) {
-  reporter.unshift(["@testdino/playwright", { token: testDinoToken }]);
-}
+  return testDinoToken
+    ? [["@testdino/playwright", { token: testDinoToken }], ...baseReporter]
+    : baseReporter;
+};
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -63,7 +66,7 @@ export default defineConfig<PlaywrightOpentelemetryUseOptions>({
   /* Opt out of parallel tests on CI. Undefined means that pw will take care of it */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter,
+  reporter: createReporter(),
   /* Shared timeout for all tests. This is useful for long-running tests. */
   globalTimeout: 15 * 60 * 1000, // 15 minutes
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from "@playwright/test";
-import type { PlaywrightTestConfig } from "@playwright/test";
 import type {
   PlaywrightOpentelemetryConfig,
   PlaywrightOpentelemetryUseOptions,
@@ -29,7 +28,7 @@ const xrayOptions = {
 
 const testDinoToken = process.env.TESTDINO_TOKEN?.trim();
 
-const reporter: NonNullable<PlaywrightTestConfig["reporter"]> = [
+const reporter = [
   ["playwright-opentelemetry/reporter"],
   ["html", { open: "on-failure" }],
   ["junit", xrayOptions],

--- a/tests/api/api_data_validation.spec.ts
+++ b/tests/api/api_data_validation.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/api/api_delete_examples.spec.ts
+++ b/tests/api/api_delete_examples.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/api/api_documentation_compliance.spec.ts
+++ b/tests/api/api_documentation_compliance.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/api/api_edge_cases.spec.ts
+++ b/tests/api/api_edge_cases.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/api/api_error_handling.spec.ts
+++ b/tests/api/api_error_handling.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/api/api_get_examples.spec.ts
+++ b/tests/api/api_get_examples.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/api/api_patch_examples.spec.ts
+++ b/tests/api/api_patch_examples.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/api/api_performance.spec.ts
+++ b/tests/api/api_performance.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/api/api_post_examples.spec.ts
+++ b/tests/api/api_post_examples.spec.ts
@@ -1,16 +1,21 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers, TEST_DATA } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
-const fs = require("fs");
-const userDataPath = `${__dirname}/../../data/users`;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const userDataPath = join(__dirname, "../../data/users");
 
 test.describe("API POST Requests - Create, Register & Login", () => {
   let apiHelper: ApiHelpers;
   let userData: any;
 
   test.beforeAll(async () => {
-    const user1Data = fs.readFileSync(`${userDataPath}/user1.json`, "utf8");
+    const user1Data = readFileSync(join(userDataPath, "user1.json"), "utf8");
     userData = JSON.parse(user1Data);
   });
 

--- a/tests/api/api_put_examples.spec.ts
+++ b/tests/api/api_put_examples.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ApiHelpers } from "../../helpers/api-helpers";
 import addApiDelay from "../../helpers/api-setup";
 

--- a/tests/web/contact.spec.ts
+++ b/tests/web/contact.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { ContactPage } from "../../pages/ContactPage";
 import { testData } from "../../data/testData";
 

--- a/tests/web/home.spec.ts
+++ b/tests/web/home.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { HomePage } from "../../pages/HomePage";
 
 test.describe("Home Tests", () => {

--- a/tests/web/navigation.spec.ts
+++ b/tests/web/navigation.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { NavigationPage } from "../../pages/NavigationPage";
 
 test.describe.skip("Navigation Tests", () => {

--- a/tests/web/performance.spec.ts
+++ b/tests/web/performance.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { HomePage } from "../../pages/HomePage";
 
 // Acceptable page load time in ms, configurable via environment variable

--- a/tests/web/todo.spec.ts
+++ b/tests/web/todo.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import TodoPage from "../../pages/TodoPage";
 
 test.describe("TodoMVC Tests", () => {

--- a/tests/web/ui_components.spec.ts
+++ b/tests/web/ui_components.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "playwright-opentelemetry/fixture";
 import { HomePage } from "../../pages/HomePage";
 
 test.describe.skip("UI Components Tests", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "strictPropertyInitialization": false,
     "esModuleInterop": true,
     "downlevelIteration": true,
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "ignoreDeprecations": "6.0"
   },
   "include": ["**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "strictPropertyInitialization": false,
     "esModuleInterop": true,
     "downlevelIteration": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules"],


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR resolves the lack of distributed tracing/observability data for our Playwright test runs.

_What problem are you trying to solve?_

Until now, when a test failed (especially intermittently, in CI), the only artifacts we had were the HTML report, screenshots, and an on-first-retry trace. That's often not enough to understand what actually happened across API calls, retries, and browser actions during a run. We're integrating this tool to get proper OpenTelemetry traces for every test, so we can inspect execution spans and drill into failures with much richer context.

## Solution

_How did you solve the problem?_

- Added the `playwright-opentelemetry` dependency and wired it into [playwright.config.ts](playwright.config.ts): registered the `playwright-opentelemetry/reporter`, enabled `storeTraceZip`, switched `trace` to `on` (always capture), and migrated the config to `defineConfig` with the `PlaywrightOpentelemetryUseOptions` typing.
- Switched the config to native ESM (`"type": "module"` in [package.json](package.json), `import "dotenv/config"` instead of `require('dotenv').config()`).
- Updated all spec files under [tests/](tests/) to import the `test`/`expect` fixtures from `playwright-opentelemetry` instead of `@playwright/test` directly, so tests pick up the tracing fixture.
- Updated [tsconfig.json](tsconfig.json) module/moduleResolution settings needed for the new ESM + type-only import setup.
- Added a CI step in [.github/workflows/playwright.yml](.github/workflows/playwright.yml) to upload the generated OpenTelemetry trace zip files (`test-results/**/*-pw-otel.zip`) as a build artifact for later inspection.